### PR TITLE
fix #19618

### DIFF
--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -60,10 +60,11 @@ class ProtocolDiscovery {
 
   void _handleLine(String line) {
     Uri uri;
-    final int index = line.indexOf(_prefix + 'http://');
-    if (index >= 0) {
+    RegExp regExp = new RegExp(r"[a-z]+:\/\/[^ \n]*");
+    Match match = regExp.firstMatch(line);
+    if (match.length > 0) {
       try {
-        uri = Uri.parse(line.substring(index + _prefix.length));
+        uri = Uri.parse(match[0]);
       } catch (error) {
         _stopScrapingLogs();
         _completer.completeError(error);

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -62,7 +62,7 @@ class ProtocolDiscovery {
     Uri uri;
     RegExp regExp = new RegExp(r"[a-z]+:\/\/[^ \n]*");
     Match match = regExp.firstMatch(line);
-    if (match.length > 0) {
+    if (match != null) {
       try {
         uri = Uri.parse(match[0]);
       } catch (error) {


### PR DESCRIPTION
A different approach to get the url from the string and avoid any interference by extra chars not allowed in url